### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,4 @@ sonar.projectName=elasticsearch-k8s-metrics-adapter
 sonar.host.url=https://sonar.elastic.dev
 sonar.go.coverage.reportPaths=coverage.out
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/vendor/**
-sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/*,**/mocks/*,internal/config/*,golangci-lint.xml,**/*.gen.go
-sonar.dbcleaner.branchesToKeepWhenInactive=main
+sonar.exclusions=**/*_test.go,**/vendor/**,**/testdata/*,**/mocks/*,internal/config/*,golangci-lint.xml,generated/**/*


### PR DESCRIPTION
This excludes generated files from scans and coverage reporting and cleans up the project keys a little.